### PR TITLE
feat: add SEO meta tags, OG image, sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,47 @@
   <title>VibeWarden — Security sidecar for vibe-coded apps</title>
   <meta name="description" content="Zero-to-secure in minutes. TLS, auth, rate limiting, WAF, and AI-readable logs. One binary, one config file.">
   <meta name="theme-color" content="#7C3AED">
+  <link rel="canonical" href="https://vibewarden.dev/">
   <link rel="icon" type="image/png" href="/static/favicon.png">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="VibeWarden">
+  <meta property="og:title" content="VibeWarden — Security sidecar for vibe-coded apps">
+  <meta property="og:description" content="Zero-to-secure in minutes. TLS, auth, rate limiting, WAF, and AI-readable logs. One binary, one config file.">
+  <meta property="og:url" content="https://vibewarden.dev/">
+  <meta property="og:image" content="https://vibewarden.dev/static/logo-text.png">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="VibeWarden — Security sidecar for vibe-coded apps">
+  <meta name="twitter:description" content="Zero-to-secure in minutes. TLS, auth, rate limiting, WAF, and AI-readable logs. One binary, one config file.">
+  <meta name="twitter:image" content="https://vibewarden.dev/static/logo-text.png">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "VibeWarden",
+    "description": "Security sidecar for vibe-coded apps. TLS, auth, rate limiting, WAF, and AI-readable structured logs.",
+    "url": "https://vibewarden.dev",
+    "applicationCategory": "SecurityApplication",
+    "operatingSystem": "Linux, macOS",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Organization",
+      "name": "VibeWarden",
+      "url": "https://vibewarden.dev",
+      "logo": "https://vibewarden.dev/static/logo.png"
+    }
+  }
+  </script>
   <style>
     /* ===== CSS Custom Properties ===== */
     :root {

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vibewarden.dev/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vibewarden.dev/</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://vibewarden.dev/docs/</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://vibewarden.dev/llms.txt</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://vibewarden.dev/llms-full.txt</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/static/og-image.html
+++ b/static/og-image.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VibeWarden OG Image Preview</title>
+  <style>
+    body { margin: 0; display: flex; align-items: center; justify-content: center; min-height: 100vh; background: #111; }
+    .og-preview {
+      width: 1200px;
+      height: 630px;
+      background: linear-gradient(135deg, #7C3AED, #06B6D4);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, -apple-system, sans-serif;
+      color: white;
+      border-radius: 8px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    }
+    .mark { font-size: 120px; font-weight: 700; line-height: 1; }
+    .name { font-size: 48px; font-weight: 600; margin-top: 16px; }
+    .tagline { font-size: 28px; opacity: 0.85; margin-top: 24px; }
+    .divider { width: 320px; height: 3px; background: rgba(255,255,255,0.4); border-radius: 1.5px; margin-top: 40px; }
+    .url { font-size: 20px; opacity: 0.7; margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <div class="og-preview">
+    <div class="mark">\V/</div>
+    <div class="name">VibeWarden</div>
+    <div class="tagline">Security sidecar for vibe-coded apps</div>
+    <div class="divider"></div>
+    <div class="url">vibewarden.dev</div>
+  </div>
+</body>
+</html>

--- a/static/og-image.svg
+++ b/static/og-image.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="600" y="260" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="120" font-weight="700" fill="white">\V/</text>
+  <text x="600" y="340" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="48" font-weight="600" fill="white">VibeWarden</text>
+  <text x="600" y="410" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="28" fill="rgba(255,255,255,0.85)">Security sidecar for vibe-coded apps</text>
+  <rect x="440" y="450" width="320" height="3" rx="1.5" fill="rgba(255,255,255,0.4)"/>
+  <text x="600" y="500" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="20" fill="rgba(255,255,255,0.7)">vibewarden.dev</text>
+</svg>


### PR DESCRIPTION
## Summary
- OG tags, Twitter Card tags, and JSON-LD structured data added to landing page
- `robots.txt` and `sitemap.xml` created at repo root
- OG image SVG + HTML preview at `static/og-image.*`
- Canonical URL and theme-color meta

Closes #18
