### PR TITLE
fix: shared navigation bar between landing page and docs

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -23,75 +23,201 @@
   --md-accent-fg-color: #06B6D4;
 }
 
-/* ===== Consistent header with landing page (#31) ===== */
+/* Match fonts with landing page */
+.md-typeset {
+  font-family: system-ui, -apple-system, sans-serif;
+}
 
-/* Light mode: white header like landing page */
-[data-md-color-scheme="default"] .md-header {
+/* ===== Shared top navigation bar (injected by theme-sync.js) ===== */
+
+#vw-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   background: #FFFFFF;
-  color: #1A1A2E;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  border-bottom: 1px solid #E8E5F0;
+  padding: 0.75rem 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
 }
-[data-md-color-scheme="default"] .md-header .md-header__title,
-[data-md-color-scheme="default"] .md-header .md-header__topic,
-[data-md-color-scheme="default"] .md-header .md-header__button,
-[data-md-color-scheme="default"] .md-header .md-source,
-[data-md-color-scheme="default"] .md-header .md-source__repository {
-  color: #1A1A2E;
+
+[data-md-color-scheme="slate"] #vw-topbar {
+  background: #1A1A2E;
+  border-bottom-color: #2A2A4A;
 }
-[data-md-color-scheme="default"] .md-header .md-header__button:hover,
-[data-md-color-scheme="default"] .md-header .md-source:hover {
+
+.vw-topbar-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.vw-topbar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: #1A1A2E;
+  text-decoration: none;
+}
+
+.vw-topbar-logo:hover { text-decoration: none; }
+
+.vw-topbar-logo img {
+  width: 28px;
+  height: 28px;
+}
+
+[data-md-color-scheme="slate"] .vw-topbar-logo {
+  color: #E2E0F0;
+}
+
+.vw-topbar-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.vw-topbar-nav a {
+  color: #4A4A6A;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.vw-topbar-nav a:hover {
+  color: #8B5CF6;
+  text-decoration: none;
+}
+
+.vw-topbar-nav a.vw-active {
+  color: #7C3AED;
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .vw-topbar-nav a {
+  color: #9A9ABB;
+}
+
+[data-md-color-scheme="slate"] .vw-topbar-nav a:hover {
+  color: #8B5CF6;
+}
+
+[data-md-color-scheme="slate"] .vw-topbar-nav a.vw-active {
+  color: #8B5CF6;
+}
+
+.vw-theme-toggle {
+  background: none;
+  border: 1px solid #E8E5F0;
+  border-radius: 8px;
+  padding: 0.4rem;
+  cursor: pointer;
+  color: #4A4A6A;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.vw-theme-toggle:hover {
+  border-color: #7C3AED;
   color: #7C3AED;
 }
-[data-md-color-scheme="default"] .md-header .md-search__input {
+
+.vw-theme-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+[data-md-color-scheme="slate"] .vw-theme-toggle {
+  border-color: #2A2A4A;
+  color: #9A9ABB;
+}
+
+[data-md-color-scheme="slate"] .vw-theme-toggle:hover {
+  border-color: #8B5CF6;
+  color: #8B5CF6;
+}
+
+/* ===== Hide MkDocs native header elements that duplicate the shared bar ===== */
+
+/* Hide the logo, palette toggle, and source repo from MkDocs header
+   since they're now in the shared top bar */
+.md-header .md-header__button.md-logo,
+.md-header .md-header__button[for="__palette_0"],
+.md-header .md-header__button[for="__palette_1"],
+.md-header [data-md-component="palette"],
+.md-header .md-header__source {
+  display: none;
+}
+
+/* Restyle remaining MkDocs header as a secondary nav (search + title) */
+.md-header {
+  position: sticky;
+  box-shadow: none;
+}
+
+[data-md-color-scheme="default"] .md-header {
   background: #F8F7FC;
   color: #1A1A2E;
 }
 
-/* Light mode tabs */
+[data-md-color-scheme="default"] .md-header .md-header__title,
+[data-md-color-scheme="default"] .md-header .md-header__topic {
+  color: #1A1A2E;
+}
+
+[data-md-color-scheme="default"] .md-header .md-search__input {
+  background: #FFFFFF;
+  color: #1A1A2E;
+}
+
+[data-md-color-scheme="default"] .md-header .md-header__button {
+  color: #4A4A6A;
+}
+
+/* Tabs restyle */
 [data-md-color-scheme="default"] .md-tabs {
   background: #F8F7FC;
   border-bottom: 1px solid #E8E5F0;
 }
+
 [data-md-color-scheme="default"] .md-tabs__link {
   color: #4A4A6A;
 }
+
 [data-md-color-scheme="default"] .md-tabs__link--active,
 [data-md-color-scheme="default"] .md-tabs__item--active .md-tabs__link {
   color: #7C3AED;
 }
 
-/* Dark mode header */
+/* Dark mode secondary header */
 [data-md-color-scheme="slate"] .md-header {
-  background: #1A1A2E;
+  background: #16162A;
   color: #E2E0F0;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
 }
+
 [data-md-color-scheme="slate"] .md-tabs {
   background: #16162A;
   border-bottom: 1px solid #2A2A4A;
 }
+
 [data-md-color-scheme="slate"] .md-tabs__link {
   color: #9A9ABB;
 }
+
 [data-md-color-scheme="slate"] .md-tabs__link--active,
 [data-md-color-scheme="slate"] .md-tabs__item--active .md-tabs__link {
   color: #8B5CF6;
 }
 
-/* Logo image should not have background square */
-.md-header__button.md-logo img,
+/* Logo image transparency */
 .md-header .md-logo img {
   background: transparent;
   object-fit: contain;
-}
-
-/* Make docs header logo link back to landing page */
-.md-header .md-logo {
-  /* The logo already links to docs home via MkDocs,
-     but visual consistency is what matters */
-}
-
-/* Match fonts with landing page */
-.md-typeset {
-  font-family: system-ui, -apple-system, sans-serif;
 }

--- a/docs/assets/javascripts/theme-sync.js
+++ b/docs/assets/javascripts/theme-sync.js
@@ -1,46 +1,98 @@
-// Sync dark mode between landing page and docs.
-// The landing page stores theme in localStorage key "theme" (dark/light).
-// MkDocs Material stores palette in "/docs/.__palette".
-// This script reads the landing page key and applies it to MkDocs on load.
+// Shared navigation bar + dark mode sync between landing page and docs.
+// Injected into all docs HTML pages. Will need to be ported to the
+// vibewarden repo's mkdocs.yml (extra_javascript) for persistence.
 (function() {
-  try {
-    var landingTheme = localStorage.getItem('theme');
-    if (!landingTheme) return;
+  var DOCS_KEY = '/docs/.__palette';
+  var THEME_KEY = 'theme';
 
-    var docsKey = '/docs/.__palette';
-    var existing = localStorage.getItem(docsKey);
-
-    // Only sync if no docs palette set yet, or if landing page was toggled more recently
-    var scheme = landingTheme === 'dark' ? 'slate' : 'default';
-    var palette = {
-      index: landingTheme === 'dark' ? 1 : 0,
-      color: {
-        scheme: scheme,
-        primary: 'deep-purple',
-        accent: 'cyan',
-        media: ''
+  // --- Theme sync ---
+  function getTheme() {
+    try {
+      var own = localStorage.getItem(THEME_KEY);
+      if (own === 'dark' || own === 'light') return own;
+      var mkdocs = JSON.parse(localStorage.getItem(DOCS_KEY));
+      if (mkdocs && mkdocs.color && mkdocs.color.scheme) {
+        return mkdocs.color.scheme === 'slate' ? 'dark' : 'light';
       }
-    };
-    localStorage.setItem(docsKey, JSON.stringify(palette));
+    } catch(e) {}
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
 
-    // Apply immediately to body
+  function saveTheme(theme) {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+      localStorage.setItem(DOCS_KEY, JSON.stringify({
+        index: theme === 'dark' ? 1 : 0,
+        color: { scheme: theme === 'dark' ? 'slate' : 'default', primary: 'deep-purple', accent: 'cyan', media: '' }
+      }));
+    } catch(e) {}
+  }
+
+  function applyTheme(theme) {
+    var scheme = theme === 'dark' ? 'slate' : 'default';
     document.body.setAttribute('data-md-color-scheme', scheme);
     document.body.setAttribute('data-md-color-primary', 'deep-purple');
     document.body.setAttribute('data-md-color-accent', 'cyan');
+    // Update toggle icon
+    var bar = document.getElementById('vw-topbar');
+    if (bar) {
+      bar.querySelector('.vw-icon-sun').style.display = theme === 'dark' ? 'none' : 'block';
+      bar.querySelector('.vw-icon-moon').style.display = theme === 'dark' ? 'block' : 'none';
+    }
+  }
 
-    // Also check the correct radio button
-    var radio = document.getElementById(landingTheme === 'dark' ? '__palette_1' : '__palette_0');
-    if (radio) radio.checked = true;
-  } catch(e) {}
+  // Apply on load
+  var currentTheme = getTheme();
+  applyTheme(currentTheme);
+  saveTheme(currentTheme);
 
-  // When docs palette changes, write back to landing page key
+  // Watch MkDocs palette changes and sync back
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(m) {
       if (m.attributeName === 'data-md-color-scheme') {
         var s = document.body.getAttribute('data-md-color-scheme');
-        try { localStorage.setItem('theme', s === 'slate' ? 'dark' : 'light'); } catch(e) {}
+        var t = s === 'slate' ? 'dark' : 'light';
+        saveTheme(t);
+        applyTheme(t);
       }
     });
   });
   observer.observe(document.body, { attributes: true, attributeFilter: ['data-md-color-scheme'] });
+
+  // --- Inject shared top navigation bar ---
+  var theme = getTheme();
+  var bar = document.createElement('div');
+  bar.id = 'vw-topbar';
+  bar.innerHTML =
+    '<div class="vw-topbar-inner">' +
+      '<a href="/" class="vw-topbar-logo">' +
+        '<img src="/static/logo.png" alt="" width="28" height="28">' +
+        '<span>VibeWarden</span>' +
+      '</a>' +
+      '<nav class="vw-topbar-nav">' +
+        '<a href="/">Home</a>' +
+        '<a href="/docs/" class="vw-active">Docs</a>' +
+        '<a href="https://github.com/vibewarden/vibewarden" rel="noopener">GitHub</a>' +
+        '<button class="vw-theme-toggle" type="button" aria-label="Toggle dark mode">' +
+          '<svg class="vw-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:' + (theme === 'dark' ? 'none' : 'block') + '">' +
+            '<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>' +
+          '</svg>' +
+          '<svg class="vw-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:' + (theme === 'dark' ? 'block' : 'none') + '">' +
+            '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>' +
+          '</svg>' +
+        '</button>' +
+      '</nav>' +
+    '</div>';
+
+  document.body.insertBefore(bar, document.body.firstChild);
+
+  // Toggle handler
+  bar.querySelector('.vw-theme-toggle').addEventListener('click', function() {
+    var next = document.body.getAttribute('data-md-color-scheme') === 'slate' ? 'light' : 'dark';
+    applyTheme(next);
+    saveTheme(next);
+    // Also trigger MkDocs palette radio so its UI stays in sync
+    var radio = document.getElementById(next === 'dark' ? '__palette_1' : '__palette_0');
+    if (radio) radio.checked = true;
+  });
 })();


### PR DESCRIPTION
## Summary
- Injects a shared top nav bar into docs pages via `theme-sync.js`
  - Logo + "VibeWarden" → links to `/` (Home)
  - Home, Docs (active), GitHub links
  - Dark mode toggle that syncs with both landing page and MkDocs palette
- Hides duplicate MkDocs header elements (logo, palette toggle, repo link)
- Restyles MkDocs header as a secondary nav bar (search + doc title + section tabs)
- Consistent light/dark mode colors across both sites

Now navigating from docs back to the landing page is one click away.

**Note:** Changes to `extra.css` and `theme-sync.js` need to be ported to the vibewarden repo's `mkdocs.yml` for persistence across docs rebuilds.
