### PR TITLE
fix: match dark mode colors and topbar sizing

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -36,18 +36,19 @@
   z-index: 100;
   background: #FFFFFF;
   border-bottom: 1px solid #E8E5F0;
-  padding: 0.75rem 1rem;
-  font-family: system-ui, -apple-system, sans-serif;
+  padding: 0.75rem 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
 [data-md-color-scheme="slate"] #vw-topbar {
-  background: #1A1A2E;
-  border-bottom-color: #2A2A4A;
+  background: #0F0E1A;
+  border-bottom-color: #2A2840;
 }
 
 .vw-topbar-inner {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 0 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -59,7 +60,7 @@
   gap: 0.5rem;
   font-weight: 700;
   font-size: 1.125rem;
-  color: #1A1A2E;
+  color: #0F0E1A;
   text-decoration: none;
 }
 
@@ -71,7 +72,7 @@
 }
 
 [data-md-color-scheme="slate"] .vw-topbar-logo {
-  color: #E2E0F0;
+  color: #E0DEF0;
 }
 
 .vw-topbar-nav {
@@ -135,7 +136,7 @@
 }
 
 [data-md-color-scheme="slate"] .vw-theme-toggle {
-  border-color: #2A2A4A;
+  border-color: #2A2840;
   color: #9A9ABB;
 }
 
@@ -164,17 +165,17 @@
 
 [data-md-color-scheme="default"] .md-header {
   background: #F8F7FC;
-  color: #1A1A2E;
+  color: #0F0E1A;
 }
 
 [data-md-color-scheme="default"] .md-header .md-header__title,
 [data-md-color-scheme="default"] .md-header .md-header__topic {
-  color: #1A1A2E;
+  color: #0F0E1A;
 }
 
 [data-md-color-scheme="default"] .md-header .md-search__input {
   background: #FFFFFF;
-  color: #1A1A2E;
+  color: #0F0E1A;
 }
 
 [data-md-color-scheme="default"] .md-header .md-header__button {
@@ -196,15 +197,15 @@
   color: #7C3AED;
 }
 
-/* Dark mode secondary header */
+/* Dark mode secondary header — slightly lighter than topbar for visual separation */
 [data-md-color-scheme="slate"] .md-header {
-  background: #16162A;
-  color: #E2E0F0;
+  background: #1A1830;
+  color: #E0DEF0;
 }
 
 [data-md-color-scheme="slate"] .md-tabs {
-  background: #16162A;
-  border-bottom: 1px solid #2A2A4A;
+  background: #1A1830;
+  border-bottom: 1px solid #2A2840;
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link {


### PR DESCRIPTION
## Summary
- Align docs topbar dark bg to `#0F0E1A` (matches landing page `--bg-primary`)
- Align border colors to `#2A2840` (matches landing page `--border-color`)
- Fix topbar padding to `0.75rem 0` with inner `padding: 0 1rem` (matches landing page container model)
- Secondary header/tabs use `#1A1830` for subtle separation
