### PR TITLE
fix: consistent nav links across all pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -294,8 +294,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
-        <a href="/blog/" class="nav-link nav-active">Blog</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/blog/why-we-built-vibewarden/index.html
+++ b/blog/why-we-built-vibewarden/index.html
@@ -376,8 +376,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
-        <a href="/blog/" class="nav-link nav-active">Blog</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/compare/cloudflare-tunnel/index.html
+++ b/compare/cloudflare-tunnel/index.html
@@ -393,7 +393,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/compare/index.html
+++ b/compare/index.html
@@ -369,7 +369,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/compare/nginx/index.html
+++ b/compare/nginx/index.html
@@ -433,7 +433,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/compare/traefik/index.html
+++ b/compare/traefik/index.html
@@ -428,7 +428,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/docs/assets/javascripts/theme-sync.js
+++ b/docs/assets/javascripts/theme-sync.js
@@ -71,7 +71,9 @@
       '</a>' +
       '<nav class="vw-topbar-nav">' +
         '<a href="/">Home</a>' +
+        '<a href="/pricing/">Pricing</a>' +
         '<a href="/docs/" class="vw-active">Docs</a>' +
+        '<a href="/support/">Support</a>' +
         '<a href="https://github.com/vibewarden/vibewarden" rel="noopener">GitHub</a>' +
         '<button class="vw-theme-toggle" type="button" aria-label="Toggle dark mode">' +
           '<svg class="vw-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:' + (theme === 'dark' ? 'none' : 'block') + '">' +

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -646,6 +646,7 @@
         <a href="/" class="nav-link">Home</a>
         <a href="/pricing/" class="nav-link nav-active">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/support/index.html
+++ b/support/index.html
@@ -547,7 +547,9 @@
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         <a href="/" class="nav-link">Home</a>
+        <a href="/pricing/" class="nav-link">Pricing</a>
         <a href="/docs/" class="nav-link">Docs</a>
+        <a href="/support/" class="nav-link nav-active">Support</a>
         <a href="https://github.com/vibewarden/vibewarden" class="nav-link" rel="noopener">GitHub</a>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode" id="themeToggle">
           <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Summary
All pages now show identical nav: `Home | Pricing | Docs | Support | GitHub`
- Landing page: Home active
- Pricing: Pricing active
- Blog/Compare: no active (sub-pages)
- Support: Support active
- Docs (via theme-sync.js): Docs active
