### PR TITLE
fix: docs topbar font size matches landing page

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -36,8 +36,10 @@
   z-index: 100;
   background: #FFFFFF;
   border-bottom: 1px solid #E8E5F0;
-  padding: 0.75rem 0;
+  padding: 12px 0;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
 }
 
 [data-md-color-scheme="slate"] #vw-topbar {
@@ -48,7 +50,7 @@
 .vw-topbar-inner {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -57,9 +59,9 @@
 .vw-topbar-logo {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   font-weight: 700;
-  font-size: 1.125rem;
+  font-size: 18px;
   color: #0F0E1A;
   text-decoration: none;
 }
@@ -78,13 +80,13 @@
 .vw-topbar-nav {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 24px;
 }
 
 .vw-topbar-nav a {
   color: #4A4A6A;
   text-decoration: none;
-  font-size: 0.9rem;
+  font-size: 14.4px;
   font-weight: 500;
 }
 
@@ -114,7 +116,7 @@
   background: none;
   border: 1px solid #E8E5F0;
   border-radius: 8px;
-  padding: 0.4rem;
+  padding: 6.4px;
   cursor: pointer;
   color: #4A4A6A;
   display: flex;
@@ -131,8 +133,8 @@
 }
 
 .vw-theme-toggle svg {
-  width: 18px;
-  height: 18px;
+  width: 18px !important;
+  height: 18px !important;
 }
 
 [data-md-color-scheme="slate"] .vw-theme-toggle {


### PR DESCRIPTION
## Summary
MkDocs Material's base font-size (0.8rem) was cascading into the shared topbar, making nav links and logo smaller on docs pages. Switched all topbar sizing from `rem` to `px` so it renders identically regardless of MkDocs base styles.
