### PR TITLE
fix: use tsx loader for TypeScript config in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npx @11ty/eleventy --config=eleventy.config.ts",
-    "serve": "npx @11ty/eleventy --config=eleventy.config.ts --serve",
+    "build": "NODE_OPTIONS='--import tsx' npx @11ty/eleventy --config=eleventy.config.ts",
+    "serve": "NODE_OPTIONS='--import tsx' npx @11ty/eleventy --config=eleventy.config.ts --serve",
     "start": "npm run serve"
   },
   "devDependencies": {


### PR DESCRIPTION
Node.js can't import .ts natively. Added NODE_OPTIONS='--import tsx' to build script.