### PR TITLE
docs(#1067): remove vibew deploy refs from website

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,7 +13,7 @@ Install vibew first:
 IMPORTANT — always use vibew init or vibew wrap. Do NOT create vibewarden.yaml,
 Dockerfile, or docker-compose files by hand. These commands generate internal
 state (.vibewarden/, health check config, compose wiring) that vibew dev and
-vibew deploy depend on. Manually created configs will fail.
+vibew bundle depend on. Manually created configs will fail.
 
 PATH A — New project:
 
@@ -1074,31 +1074,35 @@ See examples/vibewarden.prod.yaml in the repo for a complete reference.
       enabled: true
       mode: block
 
-  Generate compose file:
-    ./vibew generate --config vibewarden.prod.yaml
+Step 6 — Produce a deploy bundle locally:
+    vibew bundle --config vibewarden.prod.yaml
+    # Writes .vibewarden/bundle/ containing:
+    #   image.tar                 — docker-saved app image
+    #   docker-compose.yml        — pinned tag, deterministic
+    #   vibewarden.yaml           — merged base + prod override, strict-validated
+    #   sample.env                — template for operators
+    #   .env                      — first-run only (use --overwrite to regenerate)
+    #   deploy.sh                 — 10-line reference script (mode 0o750)
+    #   README.md                 — 3-paragraph manual-deploy guide
 
-Step 6 — Deploy:
-    rsync -av vibewarden.prod.yaml \
-      .vibewarden/generated/docker-compose.yml \
-      root@<server-ip>:/opt/myapp/
-    ssh root@<server-ip> bash -s <<'EOF'
-    mkdir -p /opt/myapp
-    echo "VIBEWARDEN_ADMIN_TOKEN=$(openssl rand -hex 32)" > /opt/myapp/.env
-    chmod 600 /opt/myapp/.env
-    EOF
-    ssh root@<server-ip> 'cd /opt/myapp && docker compose -f docker-compose.yml up -d'
+Step 7 — Ship and start:
+    scp -r .vibewarden/bundle/ root@<server-ip>:/opt/myapp/
+    ssh root@<server-ip> 'cd /opt/myapp/bundle && bash deploy.sh'
+    # deploy.sh: docker load < image.tar && docker compose up -d
 
-Step 7 — Verify:
-    ssh root@<server-ip> 'cd /opt/myapp && docker compose ps'
+Step 8 — Verify:
+    ssh root@<server-ip> 'cd /opt/myapp/bundle && docker compose ps'
     # Health check probes localhost on the remote via SSH (not the external domain):
     ssh root@<server-ip> 'curl -sf http://localhost/_vibewarden/healthz && echo OK'
     # OK
 
-Step 8 — Subsequent deploys (after code or config changes):
-    docker build -t ghcr.io/your-org/myapp:latest . && docker push ...
-    ./vibew generate --config vibewarden.prod.yaml
-    rsync -av .vibewarden/generated/docker-compose.yml root@<server-ip>:/opt/myapp/
-    ssh root@<server-ip> 'cd /opt/myapp && docker compose pull && docker compose up -d'
+Step 9 — Subsequent deploys (after code or config changes):
+    vibew bundle --config vibewarden.prod.yaml
+    scp -r .vibewarden/bundle/ root@<server-ip>:/opt/myapp/
+    ssh root@<server-ip> 'cd /opt/myapp/bundle && bash deploy.sh'
+
+Note: the legacy `vibew deploy` command (one-shot SSH orchestration) was removed
+in ADR-086. The bundle pipeline above is the only supported remote workflow.
 
 ### Troubleshooting VPS deployments
 
@@ -1217,9 +1221,12 @@ CLI commands:
   vibew build              Build Docker image for your app
   vibew restart            Restart containers without full recreate
 
-  vibew deploy --config <file> --target ssh://user@host   Deploy to remote server
-  vibew deploy status --target ssh://...                   Check remote health
-  vibew deploy logs --target ssh://... [--lines N] [--follow]  Tail (or stream) remote logs
+  vibew bundle             Produce a self-contained deploy bundle under .vibewarden/bundle/
+                           (image.tar + docker-compose.yml + merged vibewarden.yaml + deploy.sh).
+                           Ship with `scp` + `bash deploy.sh` on the server.
+
+  Note: `vibew deploy` was removed in ADR-086. The command still exists for one
+  release as a deprecation shim (prints a message and exits 2); do not use it.
 
   vibew doctor exit codes:
     0 — all checks passed (OK or WARN only)

--- a/src/start/index.njk
+++ b/src/start/index.njk
@@ -714,15 +714,12 @@ twitterDescription: "Generate a ready-to-paste prompt that sets up VibeWarden as
         prompt += '\n\nAlso enable in `vibewarden.yaml`: ' + yamlFeatures.join(', ') + '.';
       }
 
-      // Deploy
+      // Deploy — bundle + manual deploy.sh (vibew deploy was removed in ADR-086)
       if (deployTarget) {
-        if (isDomain) {
-          prompt += '\n\nDeploy to `' + deployTarget + '` using `vibew deploy --target ssh://root@' + deployTarget + '`. Install Docker on the server if not already installed. DNS is configured.';
-        } else {
-          prompt += '\n\nDeploy to server `' + deployTarget + '` using `vibew deploy --target ssh://root@' + deployTarget + '`. Install Docker on the server if not already installed.';
-        }
+        var dnsNote = isDomain ? ' DNS is configured.' : '';
+        prompt += '\n\nDeploy to `' + deployTarget + '`:\n  vibew bundle                                     # packages .vibewarden/bundle/\n  scp -r .vibewarden/bundle/ root@' + deployTarget + ':/opt/myapp/\n  ssh root@' + deployTarget + ' "cd /opt/myapp/bundle && bash deploy.sh"\nInstall Docker on the server if not already installed.' + dnsNote;
       } else {
-        prompt += '\n\nWhen the app is ready, deploy using `vibew deploy`.';
+        prompt += '\n\nWhen the app is ready, run `vibew bundle` to produce a self-contained deploy bundle under `.vibewarden/bundle/`, then scp it to the server and run `bash deploy.sh` there.';
       }
 
       outputText.value = prompt;


### PR DESCRIPTION
## Summary

Release-gating docs audit for [vibewarden/vibewarden#1067](https://github.com/VibeWarden/vibewarden/issues/1067) (scope: website repo). Removes user-facing `vibew deploy` workflow references from the authoritative sources and replaces them with the `vibew bundle` + `bash deploy.sh` pipeline per ADR-086.

## Changes

- `src/start/index.njk` — the generated setup prompt's deploy section now emits `vibew bundle` + `scp` + `bash deploy.sh` (was `vibew deploy --target ssh://root@...`). Three call sites.
- `llms-full.txt`
  - Line 16: swap "vibew dev and vibew deploy depend on" to "vibew dev and vibew bundle depend on".
  - Section 12 (VPS step-by-step): rewrote steps 6-9 to use the bundle pipeline (`vibew bundle` -> `scp -r .vibewarden/bundle/` -> `bash deploy.sh`). Added explicit note that the legacy `vibew deploy` was removed in ADR-086.
  - Section 14 (CLI Reference): replaced the three `vibew deploy*` lines with a `vibew bundle` entry plus a deprecation note.

## Scope

Only authoritative sources under `src/`, root `llms-full.txt`, and root `llms.txt` (already clean) were edited. `llms.txt` had zero hits. `install.sh` / `install.ps1` had zero hits.

## Generated docs NOT edited (follow-up needed)

`docs/vibewarden/*` is MkDocs HTML passthrough-copied from the main repo's MkDocs build. Current hit counts (must be regenerated from main repo's updated source, which landed via PRs #1056, #1058, #1060, #1061, #1064, #1069, #1070, #1071, #1072, and the parallel docs-audit PR):

| File | Hits |
|------|------|
| `docs/vibewarden/deploy-reference/index.html` | 24 |
| `docs/vibewarden/deploy-to-vps/index.html` | 5 |
| `docs/vibewarden/multi-app/index.html` | 4 |
| `docs/vibewarden/decisions/index.html` | 4 |
| `docs/vibewarden/examples/AGENTS-VIBEWARDEN/index.html` | 4 |
| `docs/vibewarden/getting-started/index.html` | 2 |
| `docs/vibewarden/troubleshooting/index.html` | 1 |
| `docs/vibewarden/search/search_index.json` | 1 |
| **Total** | **45** |

**Regeneration mechanism:** there is no automated Make target or submodule sync — the MkDocs HTML must be manually rebuilt from the main repo (`mkdocs build`) and the resulting `site/` directory copied into `docs/vibewarden/` here, then committed. Recommend wiring a `make docs` target or a GitHub Actions cross-repo trigger as a separate follow-up so this drift cannot recur.

## Verification

- `npm run build` — passes (11 files written in 0.13 s).
- `grep "vibew deploy" src/ llms-full.txt llms.txt install.sh install.ps1` — only intentional historical / deprecation-shim references remain (ADR-086 callouts on lines 1104 and 1228 of `llms-full.txt`, the comment on line 717 of `src/start/index.njk`). These are allowed by #1067's acceptance criteria ("CHANGELOG / DECISIONS / ADR historical refs OK").

## Test plan

- [ ] CI green on GitHub Pages deploy workflow.
- [ ] Visit `/start/`, fill in a deploy target, and confirm the copied prompt instructs `vibew bundle` + `scp` + `bash deploy.sh` (never `vibew deploy`).
- [ ] `curl https://vibewarden.dev/llms-full.txt | grep -c "vibew deploy"` after merge — only the two ADR-086 historical mentions should appear.
- [ ] Regenerate `docs/vibewarden/` from the main repo's MkDocs in a follow-up PR.

Generated with [Claude Code](https://claude.com/claude-code)