### PR TITLE
fix(#95): fetch agent-kickoff artifacts at build time, retire hand-rolled JS template

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,12 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Fetch kickoff artifacts from main repo's latest release
+        run: |
+          set -euo pipefail
+          mkdir -p src/_data
+          curl -fsSL -o src/_data/agent-kickoff-dev.txt https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt
+          curl -fsSL -o src/_data/agent-kickoff-deploy.txt https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt
       - run: npm run build
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_Store
 Thumbs.db
 .playwright-mcp/
+
+# Fetched at build time from the main repo's latest release (run `npm run prepare` locally)
+src/_data/agent-kickoff-*.txt

--- a/README.md
+++ b/README.md
@@ -22,15 +22,24 @@ Only files under `src/` and those listed in `eleventyConfig.addPassthroughCopy(.
 
 ## Local development
 
+The `/start/` page uses prompt templates fetched at build time from the main
+repo's latest release. These files are `.gitignore`'d. Fetch them before serving:
+
 ```bash
+npm run prepare  # downloads src/_data/agent-kickoff-{dev,deploy}.txt
 npm install
-npm run serve   # http://localhost:8080/ with hot reload
+npm run serve    # http://localhost:8080/ with hot reload
 ```
+
+`npm run prepare` can be re-run any time to refresh the templates to the latest
+release. Without it, the build still completes but the `/start/` page emits an
+obvious error placeholder instead of a real prompt.
 
 ## Build
 
 ```bash
-npm run build   # Outputs to ./dist/
+npm run prepare  # fetch kickoff artifacts (required)
+npm run build    # Outputs to ./dist/
 ```
 
 ## Deployment

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -3,8 +3,12 @@ import type { UserConfig } from "@11ty/eleventy";
 export default function (eleventyConfig: UserConfig) {
   // Filter: safely embed a string as a JSON literal inside a <script> tag.
   // Usage in nunjucks: {{ someString | jsonStringify | safe }}
+  // JSON.stringify escapes quotes and backslashes but NOT the literal string
+  // "</script>". Replace it post-stringify so the embedded JS string can't
+  // accidentally close the surrounding <script> tag if a future artifact ever
+  // contains that substring (current artifacts are clean; this is defensive).
   eleventyConfig.addFilter("jsonStringify", (value: unknown) =>
-    JSON.stringify(value)
+    JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>"),
   );
 
   // Passthrough copies — files outside src/ that go to dist/ as-is

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -1,6 +1,12 @@
 import type { UserConfig } from "@11ty/eleventy";
 
 export default function (eleventyConfig: UserConfig) {
+  // Filter: safely embed a string as a JSON literal inside a <script> tag.
+  // Usage in nunjucks: {{ someString | jsonStringify | safe }}
+  eleventyConfig.addFilter("jsonStringify", (value: unknown) =>
+    JSON.stringify(value)
+  );
+
   // Passthrough copies — files outside src/ that go to dist/ as-is
   eleventyConfig.addPassthroughCopy({ "static": "static" });
   eleventyConfig.addPassthroughCopy({ "docs": "docs" });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "NODE_OPTIONS='--import tsx' npx @11ty/eleventy --config=eleventy.config.ts",
     "serve": "NODE_OPTIONS='--import tsx' npx @11ty/eleventy --config=eleventy.config.ts --serve",
-    "start": "npm run serve"
+    "start": "npm run serve",
+    "prepare": "mkdir -p src/_data && curl -fsSL -o src/_data/agent-kickoff-dev.txt https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt && curl -fsSL -o src/_data/agent-kickoff-deploy.txt https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/src/_data/agentKickoffDeploy.js
+++ b/src/_data/agentKickoffDeploy.js
@@ -1,0 +1,34 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Resolve path relative to this file, not the cwd.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const artifactPath = resolve(__dirname, "agent-kickoff-deploy.txt");
+
+/**
+ * Eleventy global data: the body of the agent-kickoff-deploy artifact.
+ *
+ * Returns the prompt body — everything after the `# -----` divider line.
+ * If the artifact file is missing (local dev before `npm run prepare`),
+ * returns a placeholder string that makes the gap obvious.
+ */
+export default function () {
+  let raw;
+  try {
+    raw = readFileSync(artifactPath, "utf8");
+  } catch {
+    return "# ERROR: artifact not fetched. Run `npm run prepare` first.\n# Expected: src/_data/agent-kickoff-deploy.txt";
+  }
+
+  // Split on the divider line (at least 20 dashes after "# ")
+  const dividerIndex = raw.search(/^# -{20,}/m);
+  if (dividerIndex === -1) {
+    return raw;
+  }
+
+  // Find the newline after the divider line, then skip one blank line
+  const afterDivider = raw.slice(dividerIndex);
+  const newlinePos = afterDivider.indexOf("\n");
+  return afterDivider.slice(newlinePos + 1);
+}

--- a/src/_data/agentKickoffDev.js
+++ b/src/_data/agentKickoffDev.js
@@ -1,0 +1,34 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Resolve path relative to this file, not the cwd.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const artifactPath = resolve(__dirname, "agent-kickoff-dev.txt");
+
+/**
+ * Eleventy global data: the body of the agent-kickoff-dev artifact.
+ *
+ * Returns the prompt body — everything after the `# -----` divider line.
+ * If the artifact file is missing (local dev before `npm run prepare`),
+ * returns a placeholder string that makes the gap obvious.
+ */
+export default function () {
+  let raw;
+  try {
+    raw = readFileSync(artifactPath, "utf8");
+  } catch {
+    return "# ERROR: artifact not fetched. Run `npm run prepare` first.\n# Expected: src/_data/agent-kickoff-dev.txt";
+  }
+
+  // Split on the divider line (at least 20 dashes after "# ")
+  const dividerIndex = raw.search(/^# -{20,}/m);
+  if (dividerIndex === -1) {
+    return raw;
+  }
+
+  // Find the newline after the divider line, then skip one blank line
+  const afterDivider = raw.slice(dividerIndex);
+  const newlinePos = afterDivider.indexOf("\n");
+  return afterDivider.slice(newlinePos + 1);
+}

--- a/src/start/index.njk
+++ b/src/start/index.njk
@@ -482,6 +482,13 @@ twitterDescription: "Generate a ready-to-paste prompt that sets up VibeWarden as
 
         <form class="start-form" id="startForm" aria-label="Prompt generator">
 
+          <!-- Project name -->
+          <div class="form-group">
+            <label for="prjnameField">Project name</label>
+            <input class="form-input" type="text" id="prjnameField" name="prjname" placeholder="myapp">
+            <small class="field-hint">Lowercase, hyphenated, no spaces. Defaults to <code>myapp</code>.</small>
+          </div>
+
           <!-- What are you building? -->
           <div class="form-group">
             <label for="whatField">What are you building?</label>
@@ -625,6 +632,43 @@ twitterDescription: "Generate a ready-to-paste prompt that sets up VibeWarden as
 
 {% block pageScripts %}
 <script>
+  // Artifact templates fetched from the main repo's latest release at build time.
+  // Placeholders: {{prjname}}, {{description}}, {{domain}}
+  var KICKOFF_DEV = {{ agentKickoffDev | jsonStringify | safe }};
+  var KICKOFF_DEPLOY = {{ agentKickoffDeploy | jsonStringify | safe }};
+
+  /**
+   * Strip the comment header block that appears after the # ----- divider.
+   * The divider pattern is one or more `# ` lines, then a blank line, then the body.
+   * We already strip everything before the divider in the JS data files, so what
+   * remains may still start with a `# VibeWarden Agent Kickoff Prompt` header block.
+   * Strip those leading `#`-prefixed lines (and one following blank line) so the
+   * body that reaches the user is clean prose.
+   */
+  function stripLeadingComments(text) {
+    var lines = text.split('\n');
+    var i = 0;
+    // Skip lines starting with '#'
+    while (i < lines.length && lines[i].trimStart().startsWith('#')) {
+      i++;
+    }
+    // Skip one blank line after the comment block
+    if (i < lines.length && lines[i].trim() === '') {
+      i++;
+    }
+    return lines.slice(i).join('\n');
+  }
+
+  /**
+   * Substitute two-brace placeholders in a template string.
+   */
+  function fillTemplate(template, prjname, description, domain) {
+    return template
+      .replace(/\{\{prjname\}\}/g, prjname)
+      .replace(/\{\{description\}\}/g, description)
+      .replace(/\{\{domain\}\}/g, domain || '');
+  }
+
   // Auth expandable pill
   (function() {
     var wrap = document.getElementById('authPill');
@@ -656,71 +700,17 @@ twitterDescription: "Generate a ready-to-paste prompt that sets up VibeWarden as
     form.addEventListener('submit', function(e) {
       e.preventDefault();
 
-      var what = document.getElementById('whatField').value.trim();
-      if (!what) return;
-
-      // Auth config
-      var authInput = document.getElementById('featAuth');
-      var authEnabled = authInput && !authInput.disabled;
+      var prjname = (document.getElementById('prjnameField').value || '').trim() || 'myapp';
+      var description = document.getElementById('whatField').value.trim();
+      if (!description) return;
 
       // Deploy target
       var deployTarget = (document.getElementById('deployTarget').value || '').trim();
-      var isDomain = deployTarget && !/^\d+\.\d+\.\d+\.\d+$/.test(deployTarget);
 
-      // Base prompt — vibew init scaffolds in cwd, no flags needed
-      var prompt = 'Build ' + what + ' with VibeWarden as the security sidecar.\n\nVibeWarden is open source (Apache 2.0).\n  GitHub: https://github.com/vibewarden/vibewarden\n  Docs:   https://vibewarden.dev/llms-full.txt\n\nInstall: curl -fsSL https://vibewarden.dev/install.sh | sh\n  (downloads a single Go binary)';
-      prompt += '\n\nSetup:\n  mkdir myapp && cd myapp\n  vibew init';
-
-      // Post-init feature commands (vibew add)
-      var addCmds = [];
-      if (authEnabled) {
-        addCmds.push('vibew add auth');
-      }
-      if (isDomain) {
-        addCmds.push('vibew add tls --domain ' + deployTarget);
-      }
-      for (var i = 0; i < addCmds.length; i++) {
-        prompt += '\n  ' + addCmds[i];
-      }
-
-      prompt += '\n\nRun: `vibew dev`';
-      prompt += '\nThen build the app on top of the scaffolded project.';
-
-      // Auth type detail
-      if (authEnabled) {
-        var checked = document.querySelector('input[name="authType"]:checked');
-        var authType = checked ? checked.value : 'jwt';
-        if (authType === 'kratos') {
-          prompt += ' Authentication is set to built-in signup/login (Ory Kratos, `auth.mode: kratos`).';
-        } else {
-          prompt += ' Configure JWT authentication in `vibewarden.yaml` (`auth.mode: jwt` with your JWKS URL).';
-        }
-      }
-
-      // YAML-only features
-      var yamlFeatures = [];
-      var featureBoxes = form.querySelectorAll('input[name="features"][type="checkbox"]:checked');
-      for (var i = 0; i < featureBoxes.length; i++) {
-        var key = featureBoxes[i].value;
-        switch (key) {
-          case 'waf': yamlFeatures.push('WAF protection (`vibew add waf` or set `waf.enabled: true`)'); break;
-          case 'prompt': yamlFeatures.push('prompt injection detection on egress routes'); break;
-          case 'webhook': yamlFeatures.push('webhook signature verification'); break;
-          case 'secrets': yamlFeatures.push('secret management (`secrets.enabled: true` in vibewarden.yaml)'); break;
-          case 'ipfilter': yamlFeatures.push('IP filtering (`ip_filter.enabled: true`)'); break;
-        }
-      }
-      if (yamlFeatures.length > 0) {
-        prompt += '\n\nAlso enable in `vibewarden.yaml`: ' + yamlFeatures.join(', ') + '.';
-      }
-
-      // Deploy — bundle + manual deploy.sh (vibew deploy was removed in ADR-086)
-      if (deployTarget) {
-        var dnsNote = isDomain ? ' DNS is configured.' : '';
-        prompt += '\n\nDeploy to `' + deployTarget + '`:\n  vibew bundle                                     # packages .vibewarden/bundle/\n  scp -r .vibewarden/bundle/ root@' + deployTarget + ':/opt/myapp/\n  ssh root@' + deployTarget + ' "cd /opt/myapp/bundle && bash deploy.sh"\nInstall Docker on the server if not already installed.' + dnsNote;
-      } else {
-        prompt += '\n\nWhen the app is ready, run `vibew bundle` to produce a self-contained deploy bundle under `.vibewarden/bundle/`, then scp it to the server and run `bash deploy.sh` there.';
-      }
+      // Pick the right canonical template
+      var rawTemplate = deployTarget ? KICKOFF_DEPLOY : KICKOFF_DEV;
+      var body = stripLeadingComments(rawTemplate);
+      var prompt = fillTemplate(body, prjname, description, deployTarget);
 
       outputText.value = prompt;
       outputArea.classList.add('visible');


### PR DESCRIPTION
Closes vibewarden/vibewarden.dev#95

Fixes the drift caught in three consecutive retros (v0.18.1, v0.18.2, v0.18.3): the website's hand-rolled JS template had the wrong deploy recipe and was not tracking the canonical contract.

## What changed

The `/start/` page prompt is now driven by the same artifacts that ship in the main repo's release (added in VibeWarden/vibewarden#1232, ADR-101):
- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`
- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt`

## Before / after — deploy block

**Before** (hand-rolled, wrong):
```
vibew bundle
scp -r .vibewarden/bundle/ root@<server>:/opt/myapp/
ssh root@<server> "cd /opt/myapp/bundle && bash deploy.sh"
```

**After** (from canonical artifact, ADR-099 recipe):
```
ssh user@<domain> 'mkdir -p /opt/myapp'
tar -czf - -C .vibewarden/bundle . | ssh user@<domain> 'tar -xzf - -C /opt/myapp/'
ssh user@<domain> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
```

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | Add `curl` fetch step before `npm run build` |
| `src/_data/agentKickoffDev.js` | Eleventy global data — reads + strips header from dev artifact |
| `src/_data/agentKickoffDeploy.js` | Eleventy global data — reads + strips header from deploy artifact |
| `eleventy.config.ts` | Add `jsonStringify` filter for safe `<script>` embedding |
| `src/start/index.njk` | Inject templates, replace `var prompt = '...'` with `fillTemplate()`, add project name field |
| `package.json` | Add `prepare` script for local dev artifact fetch |
| `.gitignore` | Exclude `src/_data/agent-kickoff-*.txt` (fetched, not committed) |
| `README.md` | Document `npm run prepare` for local dev |

## Local fallback

If artifacts are missing, `agentKickoffDev.js` / `agentKickoffDeploy.js` return an obvious error placeholder (`# ERROR: artifact not fetched. Run npm run prepare first.`). The build does not break — the gap is surfaced to the developer immediately.

## Test plan

- [x] `npm run build` succeeds with artifacts present
- [x] `grep -E "tar -czf|docker compose up" dist/start/index.html` — present
- [x] `grep "bash deploy.sh" dist/start/index.html` — absent
- [x] Project name field renders, defaults to `myapp`
- [x] Dev template used when deploy target is empty; deploy template used when set